### PR TITLE
Switch toString sink overload back to 'in' parameter

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,9 +1,8 @@
 {
-	"name": "bitblob",
-	"authors": [
-		"Mathias 'Geod24' Lang"
-	],
-	"description": "A small library to represent hash types as value types",
-	"copyright": "Copyright © 2018, Mathias 'Geod24' Lang",
-	"license": "MIT"
+    "name": "bitblob",
+    "description": "A small library to represent hash types as value types",
+
+    "license": "MIT",
+    "authors": [ "Mathias 'Geod24' Lang" ],
+    "copyright": "Copyright © 2018, Mathias 'Geod24' Lang"
 }

--- a/source/geod24/bitblob.d
+++ b/source/geod24/bitblob.d
@@ -82,14 +82,14 @@ public struct BitBlob (size_t Size)
 
     ***************************************************************************/
 
-    public void toString (scope void delegate(const(char)[]) @safe sink) const
+    public void toString (scope void delegate(in char[]) @safe sink) const
     {
         FormatSpec!char spec;
         this.toString(sink, spec);
     }
 
     /// Ditto
-    public void toString (scope void delegate(const(char)[]) @safe sink,
+    public void toString (scope void delegate(in char[]) @safe sink,
                           scope const ref FormatSpec!char spec) const
     {
         /// Used for formatting
@@ -136,7 +136,7 @@ public struct BitBlob (size_t Size)
     {
         size_t idx;
         char[StringBufferSize] buffer = void;
-        scope sink = (const(char)[] v) {
+        scope sink = (in char[] v) {
                 buffer[idx .. idx + v.length] = v;
                 idx += v.length;
             };


### PR DESCRIPTION
```
Now that the bug has been fixed for a few release (v2.096.1),
we can revert to using 'in', especially as it only affect
users of '-preview=in', which are bleeding edge users.
```